### PR TITLE
Moved parentheses in pStats1 calculation so that it would compile

### DIFF
--- a/basketball_shell.scala
+++ b/basketball_shell.scala
@@ -386,8 +386,8 @@ val pStats1=pStats.map{ case(name,stats) =>
               eList += ((exp, Array(valueZ,valueN,deltaZ,deltaN)))
               exp += 1
           }
-          (aList,eList)
      })
+     (aList,eList)
 }
 
 pStats1.cache

--- a/basketball_shell.scala
+++ b/basketball_shell.scala
@@ -385,9 +385,9 @@ val pStats1=pStats.map{ case(name,stats) =>
           if (!excludeNames.contains(z._1)){
               eList += ((exp, Array(valueZ,valueN,deltaZ,deltaN)))
               exp += 1
-          })
+          }
           (aList,eList)
-     }
+     })
 }
 
 pStats1.cache


### PR DESCRIPTION
Pasting the pStats1 code into spark-shell wasn't compiling:

<console>:25: error: ';' expected but ')' found.
                 })
                  ^
<console>:28: error: ')' expected but '}' found.
       }

Parentheses was just in the wrong place. After moving it, compiles:

pStats1: org.apache.spark.rdd.RDD[Unit] = MapPartitionsRDD[105] at map at <console>:65
res10: pStats1.type = MapPartitionsRDD[105] at map at <console>:65
